### PR TITLE
feat: ブログページとタグページのUIをトップページスタイルに統一

### DIFF
--- a/src/app/_components/Hero/BrandStory.tsx
+++ b/src/app/_components/Hero/BrandStory.tsx
@@ -115,7 +115,7 @@ export const ScrollingMain = () => {
         transition={{ duration: 0.8 }}
         className="relative z-10 aspect-square size-[250px] overflow-hidden md:size-[450px]"
       >
-        <div className="absolute top-0 z-20 w-full rounded-t-[20px] border-2 border-b-0 border-black py-1 md:py-2">
+        <div className="absolute top-0 z-20 w-full rounded-t-[20px] border-2 border-b-0 border-black bg-gradient-main py-1 md:py-2">
           <Marquee
             gradient={false}
             speed={50}

--- a/src/app/_components/Hero/blog.tsx
+++ b/src/app/_components/Hero/blog.tsx
@@ -89,7 +89,7 @@ export const BlogSection = ({ blogs }: BlogSectionProps) => {
                           <span className="text-gray-400">No Image</span>
                         </div>
                       )}
-                      <div className="absolute left-4 top-4 rounded-full bg-primary px-3 py-1 text-sm text-white">
+                      <div className="absolute left-4 top-4 rounded-full bg-primary-dark px-3 py-1 text-sm text-white">
                         {blogs[0].category.name}
                       </div>
                     </div>
@@ -231,7 +231,7 @@ const CompactBlogCard = ({ blog, index }: { blog: Blog; index: number }) => {
                 <span className="text-gray-400">No Image</span>
               </div>
             )}
-            <div className="absolute left-2 top-2 rounded-full bg-primary px-2 py-1 text-xs text-white">
+            <div className="absolute left-2 top-2 rounded-full bg-primary-dark px-2 py-1 text-xs text-white">
               {blog.category.name}
             </div>
           </div>
@@ -241,14 +241,14 @@ const CompactBlogCard = ({ blog, index }: { blog: Blog; index: number }) => {
               <CalendarIcon className="mr-1 h-3 w-3" />
               <p>{formatDate(blog.publishedAt)}</p>
             </div>
-            <h3 className="mb-1 line-clamp-2 text-sm font-bold group-hover:text-primary">
+            <h3 className="mb-1 line-clamp-2 text-sm font-bold text-gray-800 transition-colors group-hover:text-primary-dark">
               {blog.title}
             </h3>
 
             <div className="mt-auto flex justify-end pt-2">
               <motion.span
                 whileHover={{ x: 3 }}
-                className="text-xs font-medium text-primary"
+                className="text-xs font-semibold text-primary-dark transition-colors hover:text-primary"
               >
                 続きを読む →
               </motion.span>

--- a/src/app/_components/blog/CategoryNavigation.tsx
+++ b/src/app/_components/blog/CategoryNavigation.tsx
@@ -42,7 +42,7 @@ export const CategoryNavigation = ({
           <button
             onClick={() => onCategoryClick?.(null)}
             className={`group relative overflow-hidden rounded-full border-2 border-black px-4 py-2 text-sm font-medium transition-all hover:shadow-md ${
-              activeCategory === null || activeCategory === "all" 
+              activeCategory === undefined || activeCategory === "all" 
                 ? "bg-primary-dark text-white" 
                 : "bg-white hover:border-primary hover:text-primary"
             }`}

--- a/src/app/_components/blog/CategoryNavigation.tsx
+++ b/src/app/_components/blog/CategoryNavigation.tsx
@@ -1,58 +1,124 @@
+"use client";
+
 import Link from "next/link";
+import { motion } from "framer-motion";
 import { BlogCategory } from "@/libs/client";
+import { TagIcon } from "lucide-react";
 
 type CategoryNavigationProps = {
   categories: BlogCategory[];
   activeCategory?: string;
   className?: string;
+  showAllCount?: number; // "すべて"の記事数
+  categoryCounts?: Record<string, number>; // 各カテゴリーの記事数
+  variant?: "default" | "filter"; // スタイルバリエーション
+  onCategoryClick?: (slug: string | null) => void; // フィルター用のクリックハンドラー
 };
 
 export const CategoryNavigation = ({
   categories,
   activeCategory,
   className = "",
+  showAllCount,
+  categoryCounts,
+  variant = "default",
+  onCategoryClick,
 }: CategoryNavigationProps) => {
+  const isFilter = variant === "filter";
+
   return (
-    <div
-      className={`rounded-xl border border-gray-100 bg-white/90 p-6 shadow-md backdrop-blur-md transition-all hover:shadow-lg ${className}`}
-    >
-      <h2 className="mb-6 font-sans text-xl font-semibold text-gray-800">
-        カテゴリ
+    <div className={`rounded-[20px] border-2 border-black bg-white p-6 shadow-lg ${className}`}>
+      <h2 className="mb-4 flex items-center gap-2 font-shippori-antique-b1 text-xl font-bold">
+        {isFilter && (
+          <span className="rounded-full bg-primary p-2 text-white">
+            <TagIcon className="h-4 w-4" />
+          </span>
+        )}
+        {isFilter ? "カテゴリーで絞り込む" : "カテゴリー"}
       </h2>
       <div className="flex flex-wrap gap-3">
-        <Link
-          href="/blogs/all"
-          className={`group flex items-center rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
-            !activeCategory
-              ? "bg-primary text-white shadow-sm"
-              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-          }`}
-        >
-          <span className="relative">
-            すべて
-            {!activeCategory && (
-              <span className="absolute -bottom-1 left-0 h-0.5 w-0 bg-white transition-all duration-300 group-hover:w-full"></span>
-            )}
-          </span>
-        </Link>
-        {categories.map((category) => (
-          <Link
-            key={category.id}
-            href={`/blogs/${category.slug}`}
-            className={`group flex items-center rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
-              activeCategory === category.slug
-                ? "bg-primary text-white shadow-sm"
-                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+        {/* すべての記事 */}
+        {isFilter ? (
+          <button
+            onClick={() => onCategoryClick?.(null)}
+            className={`group relative overflow-hidden rounded-full border-2 border-black px-4 py-2 text-sm font-medium transition-all hover:shadow-md ${
+              activeCategory === null || activeCategory === "all" 
+                ? "bg-primary-dark text-white" 
+                : "bg-white hover:border-primary hover:text-primary"
             }`}
           >
-            <span className="relative">
-              {category.name}
-              {activeCategory === category.slug && (
-                <span className="absolute -bottom-1 left-0 h-0.5 w-0 bg-white transition-all duration-300 group-hover:w-full"></span>
-              )}
+            <span className="relative z-10">
+              すべて{showAllCount !== undefined && ` (${showAllCount})`}
             </span>
+          </button>
+        ) : (
+          <Link
+            href="/blogs/all"
+            className={`group relative overflow-hidden rounded-full border-2 border-black px-4 py-2 text-sm font-medium transition-all hover:shadow-md ${
+              activeCategory === "all" 
+                ? "bg-primary-dark text-white" 
+                : "bg-gradient-main hover:border-primary hover:shadow-md"
+            }`}
+          >
+            <span className="relative z-10">すべての記事</span>
+            {activeCategory !== "all" && (
+              <motion.div
+                className="absolute inset-0 bg-primary"
+                initial={{ x: "-100%" }}
+                whileHover={{ x: 0 }}
+                transition={{ duration: 0.3 }}
+              />
+            )}
           </Link>
-        ))}
+        )}
+
+        {/* カテゴリー一覧 */}
+        {categories.map((category) => {
+          const count = categoryCounts?.[category.slug];
+          const isActive = activeCategory === category.slug;
+
+          if (isFilter) {
+            return (
+              <button
+                key={category.id}
+                onClick={() => onCategoryClick?.(category.slug)}
+                className={`group relative overflow-hidden rounded-full border-2 border-black px-4 py-2 text-sm font-medium transition-all hover:shadow-md ${
+                  isActive 
+                    ? "bg-primary-dark text-white" 
+                    : "bg-white hover:border-primary hover:text-primary"
+                }`}
+              >
+                <span className="relative z-10">
+                  {category.name}{count !== undefined && ` (${count})`}
+                </span>
+              </button>
+            );
+          }
+
+          return (
+            <Link
+              key={category.id}
+              href={`/blogs/${category.slug}`}
+              className={`group relative overflow-hidden rounded-full border-2 border-black px-4 py-2 text-sm font-medium transition-all hover:shadow-md ${
+                isActive 
+                  ? "bg-primary-dark text-white" 
+                  : "bg-white"
+              }`}
+            >
+              <span className={`relative z-10 ${!isActive && "transition-colors group-hover:text-white"}`}>
+                {category.name}
+              </span>
+              {!isActive && (
+                <motion.div
+                  className="absolute inset-0 bg-primary"
+                  initial={{ x: "-100%" }}
+                  whileHover={{ x: 0 }}
+                  transition={{ duration: 0.3 }}
+                />
+              )}
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/blogs/BlogPageClient.tsx
+++ b/src/app/blogs/BlogPageClient.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import Image from "next/image";
+import { useRef } from "react";
+import { Blog, BlogCategory } from "@/libs/client";
+import { LogoLink2 } from "../_components/common/LogoLink2";
+import { CategoryNavigation } from "../_components/blog/CategoryNavigation";
+import { CalendarIcon } from "lucide-react";
+
+type BlogPageClientProps = {
+  categories: BlogCategory[];
+  latestBlogs: Blog[];
+  allBlogs: Blog[];
+};
+
+export function BlogPageClient({ categories, latestBlogs, allBlogs }: BlogPageClientProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // スクロールコントロール
+  const handleScrollLeft = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: -300,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const handleScrollRight = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: 300,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  // 日付フォーマット関数
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+  };
+
+  return (
+    <section className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
+      <LogoLink2 />
+      <div className="container mx-auto">
+        {/* ヘッダー */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-8 md:mb-12"
+        >
+          <p className="text-base font-semibold md:text-2xl">BLOG</p>
+          <h1 className="mb-4 font-shippori-antique-b1 text-3xl font-medium md:text-5xl">
+            ブログ
+          </h1>
+          <p className="max-w-2xl text-gray-700">
+            下呂市小坂町の釣り場「川の家おさか」の釣り情報、初心者向けガイド、釣った魚のレシピなど様々な情報を発信しています。
+          </p>
+        </motion.div>
+
+        {/* カテゴリーナビゲーション */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+        >
+          <CategoryNavigation 
+            categories={categories} 
+            className="mb-12"
+          />
+        </motion.div>
+
+        {/* 最新記事（大きく表示） */}
+        {latestBlogs.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
+            className="mb-12"
+          >
+            <h2 className="mb-6 font-shippori-antique-b1 text-2xl font-bold md:text-3xl">
+              最新記事
+            </h2>
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-12">
+              <div className="md:col-span-7">
+                <FeaturedBlogCard blog={latestBlogs[0]} formatDate={formatDate} />
+              </div>
+              <div className="flex flex-col justify-center md:col-span-5">
+                <motion.div
+                  initial={{ opacity: 0, x: 50 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.5, delay: 0.3 }}
+                >
+                  <h3 className="mb-4 font-shippori-antique-b1 text-xl md:text-2xl">
+                    {allBlogs.length}件の記事から
+                    <br />
+                    お気に入りを見つけよう
+                  </h3>
+                  <p className="mb-6 text-gray-700">
+                    釣りのコツや季節の情報、地元の魅力など、川の家おさかならではの情報をお届けしています。
+                  </p>
+                  <Link
+                    href="/blogs/tags"
+                    className="group inline-flex items-center gap-2 font-bold text-black transition-colors hover:text-primary"
+                  >
+                    <span>タグから探す</span>
+                    <span className="grid place-items-center rounded-full border-2 border-black bg-white p-2 transition-transform group-hover:translate-x-1">
+                      <Image
+                        src="/common/arrow.svg"
+                        alt="矢印"
+                        width={16}
+                        height={16}
+                      />
+                    </span>
+                  </Link>
+                </motion.div>
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        {/* その他の記事 */}
+        {latestBlogs.length > 1 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.4 }}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="font-shippori-antique-b1 text-2xl font-bold md:text-3xl">
+                記事一覧
+              </h2>
+              <div className="flex space-x-2">
+                <motion.button
+                  whileHover={{ scale: 1.1 }}
+                  whileTap={{ scale: 0.9 }}
+                  onClick={handleScrollLeft}
+                  className="grid h-10 w-10 place-items-center rounded-full border-2 border-black bg-white shadow-md"
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24">
+                    <path
+                      fill="currentColor"
+                      d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"
+                    />
+                  </svg>
+                </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.1 }}
+                  whileTap={{ scale: 0.9 }}
+                  onClick={handleScrollRight}
+                  className="grid h-10 w-10 place-items-center rounded-full border-2 border-black bg-white shadow-md"
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24">
+                    <path
+                      fill="currentColor"
+                      d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                    />
+                  </svg>
+                </motion.button>
+              </div>
+            </div>
+
+            <div
+              ref={scrollContainerRef}
+              className="hide-scrollbar -mx-4 flex overflow-x-auto px-4 pb-8"
+            >
+              {latestBlogs.slice(1).map((blog, index) => (
+                <BlogCard key={blog.id} blog={blog} index={index} formatDate={formatDate} />
+              ))}
+            </div>
+          </motion.div>
+        )}
+
+        {/* すべての記事を見るボタン */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.5 }}
+          className="mt-12 text-center"
+        >
+          <Link
+            href="/blogs/all"
+            className="group inline-flex items-center gap-2 rounded-full border-2 border-black bg-primary px-6 py-3 font-bold text-white shadow-lg transition-all hover:bg-primary-dark hover:shadow-xl"
+          >
+            <span>すべての記事を見る</span>
+            <motion.span
+              animate={{ x: [0, 3, 0] }}
+              transition={{ duration: 1.5, repeat: Infinity }}
+            >
+              →
+            </motion.span>
+          </Link>
+        </motion.div>
+      </div>
+
+      {/* カスタムスタイル */}
+      <style jsx global>{`
+        .hide-scrollbar::-webkit-scrollbar {
+          display: none;
+        }
+        .hide-scrollbar {
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+        }
+      `}</style>
+    </section>
+  );
+}
+
+// 特集記事カード
+const FeaturedBlogCard = ({ blog, formatDate }: { blog: Blog; formatDate: (date: string) => string }) => {
+  return (
+    <motion.div
+      whileHover={{ scale: 1.02 }}
+      transition={{ duration: 0.3 }}
+    >
+      <Link href={`/blogs/${blog.category.slug}/${blog.slug}`}>
+        <div className="group relative overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg">
+          <div className="relative aspect-[16/9] w-full">
+            {blog.eyecatch ? (
+              <Image
+                src={blog.eyecatch.url}
+                alt={blog.title}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gray-200">
+                <span className="text-gray-400">No Image</span>
+              </div>
+            )}
+            <div className="absolute left-4 top-4 rounded-full bg-primary-dark px-3 py-1 text-sm font-bold text-white">
+              {blog.category.name}
+            </div>
+          </div>
+
+          <div className="p-6">
+            <div className="mb-2 flex items-center text-sm text-gray-600">
+              <CalendarIcon className="mr-1 h-4 w-4" />
+              <p>{formatDate(blog.publishedAt)}</p>
+            </div>
+            <h3 className="mb-3 text-xl font-bold text-gray-800 transition-colors group-hover:text-primary">
+              {blog.title}
+            </h3>
+            {blog.description && (
+              <p className="mb-4 line-clamp-2 text-gray-600">
+                {blog.description}
+              </p>
+            )}
+            <div className="flex items-center justify-between">
+              {blog.tags && blog.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {blog.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                    >
+                      #{tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <motion.span
+                className="text-sm font-semibold text-primary-dark"
+                whileHover={{ x: 3 }}
+              >
+                続きを読む →
+              </motion.span>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  );
+};
+
+// ブログカード
+const BlogCard = ({ 
+  blog, 
+  index, 
+  formatDate 
+}: { 
+  blog: Blog; 
+  index: number; 
+  formatDate: (date: string) => string;
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: index * 0.1 }}
+      className="mr-4 flex-shrink-0 overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg"
+      style={{ width: "320px", maxWidth: "100%" }}
+    >
+      <Link href={`/blogs/${blog.category.slug}/${blog.slug}`}>
+        <div className="group flex h-full flex-col">
+          <div className="relative h-48">
+            {blog.eyecatch ? (
+              <Image
+                src={blog.eyecatch.url}
+                alt={blog.title}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gray-200">
+                <span className="text-gray-400">No Image</span>
+              </div>
+            )}
+            <div className="absolute left-3 top-3 rounded-full bg-primary-dark px-3 py-1 text-xs font-bold text-white">
+              {blog.category.name}
+            </div>
+          </div>
+
+          <div className="flex flex-1 flex-col p-4">
+            <div className="mb-2 flex items-center text-xs text-gray-500">
+              <CalendarIcon className="mr-1 h-3 w-3" />
+              <p>{formatDate(blog.publishedAt)}</p>
+            </div>
+            <h3 className="mb-2 line-clamp-2 text-base font-bold text-gray-800 transition-colors group-hover:text-primary">
+              {blog.title}
+            </h3>
+            {blog.description && (
+              <p className="mb-3 line-clamp-2 text-sm text-gray-600">
+                {blog.description}
+              </p>
+            )}
+
+            <div className="mt-auto flex items-center justify-between">
+              {blog.tags && blog.tags.length > 0 && (
+                <div className="flex gap-1">
+                  {blog.tags.slice(0, 2).map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                    >
+                      #{tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <motion.span
+                whileHover={{ x: 3 }}
+                className="text-xs font-semibold text-primary-dark"
+              >
+                続きを読む →
+              </motion.span>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  );
+};

--- a/src/app/blogs/[category]/CategoryPageClient.tsx
+++ b/src/app/blogs/[category]/CategoryPageClient.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import Image from "next/image";
+import { Blog, BlogCategory } from "@/libs/client";
+import { LogoLink2 } from "@/app/_components/common/LogoLink2";
+import { CategoryNavigation } from "@/app/_components/blog/CategoryNavigation";
+import { CalendarIcon, TagIcon, FishIcon, UsersIcon, BookOpenIcon, UtensilsIcon } from "lucide-react";
+
+type CategoryPageClientProps = {
+  currentCategory: BlogCategory;
+  categories: BlogCategory[];
+  blogs: Blog[];
+};
+
+// カテゴリー別の情報
+const categoryInfo: Record<string, {
+  icon: React.ReactNode;
+  color: string;
+  bgColor: string;
+  description: string;
+}> = {
+  "fishing-info": {
+    icon: <FishIcon className="h-6 w-6" />,
+    color: "text-blue-600",
+    bgColor: "bg-blue-100",
+    description: "釣り場の状況、おすすめの釣り方、季節ごとの魚の情報など、釣りに関する最新情報をお届けします。",
+  },
+  "family-guide": {
+    icon: <UsersIcon className="h-6 w-6" />,
+    color: "text-green-600",
+    bgColor: "bg-green-100",
+    description: "ファミリーで楽しむための釣りガイド。お子様連れでも安心して楽しめるコツや注意点をご紹介。",
+  },
+  "beginner-tips": {
+    icon: <BookOpenIcon className="h-6 w-6" />,
+    color: "text-purple-600",
+    bgColor: "bg-purple-100",
+    description: "釣り初心者の方向けの基本的な知識やテクニック。道具の選び方から釣り方まで丁寧に解説します。",
+  },
+  "recipe": {
+    icon: <UtensilsIcon className="h-6 w-6" />,
+    color: "text-orange-600",
+    bgColor: "bg-orange-100",
+    description: "釣った魚を美味しく食べるためのレシピ集。地元の伝統料理から創作料理まで幅広くご紹介。",
+  },
+};
+
+export function CategoryPageClient({ currentCategory, categories, blogs }: CategoryPageClientProps) {
+  const categoryData = categoryInfo[currentCategory.slug] || {
+    icon: <TagIcon className="h-6 w-6" />,
+    color: "text-primary",
+    bgColor: "bg-primary/10",
+    description: `${currentCategory.name}に関する記事一覧です。`,
+  };
+
+  // 日付フォーマット関数
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+  };
+
+  // 最新記事と人気記事（仮）を分ける
+  const latestBlog = blogs[0];
+  const otherBlogs = blogs.slice(1);
+
+  return (
+    <section className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
+      <LogoLink2 />
+      <div className="container mx-auto">
+        {/* ヘッダー */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-8 md:mb-12"
+        >
+          <Link
+            href="/blogs"
+            className="mb-4 inline-flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary"
+          >
+            <span>←</span>
+            <span>ブログトップに戻る</span>
+          </Link>
+          
+          {/* カテゴリーアイコンとタイトル */}
+          <div className="mb-6 flex items-center gap-4">
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ duration: 0.5, type: "spring" }}
+              className={`rounded-full p-4 ${categoryData.bgColor}`}
+            >
+              <span className={categoryData.color}>{categoryData.icon}</span>
+            </motion.div>
+            <div>
+              <p className="text-base font-semibold md:text-2xl">CATEGORY</p>
+              <h1 className="font-shippori-antique-b1 text-3xl font-medium md:text-5xl">
+                {currentCategory.name}
+              </h1>
+            </div>
+          </div>
+          
+          <p className="max-w-2xl text-gray-700">
+            {categoryData.description}
+          </p>
+          <p className="mt-2 text-sm text-gray-600">
+            {blogs.length}件の記事があります
+          </p>
+        </motion.div>
+
+        {/* カテゴリーナビゲーション */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+        >
+          <CategoryNavigation
+            categories={categories}
+            activeCategory={currentCategory.slug}
+            className="mb-12"
+          />
+        </motion.div>
+
+        {/* 記事一覧 */}
+        {blogs.length > 0 ? (
+          <>
+            {/* 最新記事を大きく表示 */}
+            {latestBlog && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.2 }}
+                className="mb-12"
+              >
+                <h2 className="mb-6 font-shippori-antique-b1 text-2xl font-bold">
+                  最新記事
+                </h2>
+                <FeaturedBlogCard blog={latestBlog} formatDate={formatDate} categoryData={categoryData} />
+              </motion.div>
+            )}
+
+            {/* その他の記事 */}
+            {otherBlogs.length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.3 }}
+              >
+                <h2 className="mb-6 font-shippori-antique-b1 text-2xl font-bold">
+                  その他の記事
+                </h2>
+                <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                  {otherBlogs.map((blog, index) => (
+                    <BlogCard 
+                      key={blog.id} 
+                      blog={blog} 
+                      index={index}
+                      formatDate={formatDate}
+                    />
+                  ))}
+                </div>
+              </motion.div>
+            )}
+          </>
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="rounded-[20px] border-2 border-black bg-white p-8 text-center shadow-lg"
+          >
+            <div className={`mx-auto mb-4 rounded-full p-4 ${categoryData.bgColor} inline-block`}>
+              <span className={categoryData.color}>{categoryData.icon}</span>
+            </div>
+            <p className="mb-4 text-lg font-medium">
+              このカテゴリにはまだ記事がありません。
+            </p>
+            <Link
+              href="/blogs"
+              className="group inline-flex items-center gap-2 font-bold text-black transition-colors hover:text-primary"
+            >
+              <span>ブログトップに戻る</span>
+              <span className="grid place-items-center rounded-full border-2 border-black bg-white p-2 transition-transform group-hover:translate-x-1">
+                <Image
+                  src="/common/arrow.svg"
+                  alt="矢印"
+                  width={16}
+                  height={16}
+                />
+              </span>
+            </Link>
+          </motion.div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// 特集記事カード
+const FeaturedBlogCard = ({ 
+  blog, 
+  formatDate,
+  categoryData 
+}: { 
+  blog: Blog; 
+  formatDate: (date: string) => string;
+  categoryData: any;
+}) => {
+  return (
+    <Link href={`/blogs/${blog.category.slug}/${blog.slug}`}>
+      <motion.div
+        whileHover={{ scale: 1.02 }}
+        transition={{ duration: 0.3 }}
+        className="group grid grid-cols-1 gap-6 overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg md:grid-cols-2"
+      >
+        <div className="relative h-64 md:h-auto">
+          {blog.eyecatch ? (
+            <Image
+              src={blog.eyecatch.url}
+              alt={blog.title}
+              fill
+              className="object-cover transition-transform duration-300 group-hover:scale-105"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-gray-200">
+              <span className="text-gray-400">No Image</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col justify-center p-6">
+          <div className="mb-3 flex items-center gap-3">
+            <span className={`rounded-full px-3 py-1 text-sm font-bold ${categoryData.bgColor} ${categoryData.color}`}>
+              {blog.category.name}
+            </span>
+            <div className="flex items-center text-sm text-gray-600">
+              <CalendarIcon className="mr-1 h-4 w-4" />
+              <p>{formatDate(blog.publishedAt)}</p>
+            </div>
+          </div>
+          
+          <h3 className="mb-3 text-2xl font-bold text-gray-800 transition-colors group-hover:text-primary">
+            {blog.title}
+          </h3>
+          
+          {blog.description && (
+            <p className="mb-4 line-clamp-3 text-gray-600">
+              {blog.description}
+            </p>
+          )}
+          
+          {blog.tags && blog.tags.length > 0 && (
+            <div className="mb-4 flex flex-wrap gap-1">
+              {blog.tags.map((tag) => (
+                <span
+                  key={tag.id}
+                  className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                >
+                  #{tag.name}
+                </span>
+              ))}
+            </div>
+          )}
+          
+          <motion.span
+            className="inline-flex items-center text-sm font-semibold text-primary-dark"
+            whileHover={{ x: 3 }}
+          >
+            続きを読む →
+          </motion.span>
+        </div>
+      </motion.div>
+    </Link>
+  );
+};
+
+// ブログカード
+const BlogCard = ({ 
+  blog, 
+  index,
+  formatDate 
+}: { 
+  blog: Blog; 
+  index: number;
+  formatDate: (date: string) => string;
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: index * 0.05 }}
+      whileHover={{ y: -5 }}
+      className="h-full"
+    >
+      <Link href={`/blogs/${blog.category.slug}/${blog.slug}`}>
+        <div className="group flex h-full flex-col overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg transition-all hover:shadow-xl">
+          <div className="relative h-48">
+            {blog.eyecatch ? (
+              <Image
+                src={blog.eyecatch.url}
+                alt={blog.title}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gray-200">
+                <span className="text-gray-400">No Image</span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-1 flex-col p-5">
+            <div className="mb-2 flex items-center text-xs text-gray-500">
+              <CalendarIcon className="mr-1 h-3 w-3" />
+              <p>{formatDate(blog.publishedAt)}</p>
+            </div>
+            <h3 className="mb-2 line-clamp-2 text-lg font-bold text-gray-800 transition-colors group-hover:text-primary">
+              {blog.title}
+            </h3>
+            {blog.description && (
+              <p className="mb-3 line-clamp-2 text-sm text-gray-600">
+                {blog.description}
+              </p>
+            )}
+
+            <div className="mt-auto">
+              {blog.tags && blog.tags.length > 0 && (
+                <div className="mb-3 flex flex-wrap gap-1">
+                  {blog.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                    >
+                      #{tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div className="flex items-center justify-end">
+                <motion.span
+                  whileHover={{ x: 3 }}
+                  className="text-sm font-semibold text-primary-dark"
+                >
+                  続きを読む →
+                </motion.span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  );
+};

--- a/src/app/blogs/[category]/[slug]/page.tsx
+++ b/src/app/blogs/[category]/[slug]/page.tsx
@@ -74,22 +74,20 @@ export default async function BlogPostPage({ params }: Props) {
   // 新しいtagsフィールドを使用
   const tags = blog.tags && Array.isArray(blog.tags) ? blog.tags : [];
 
-  // 同じカテゴリの他の記事から3つ取得（関連記事用）
+  // 同じカテゴリの他の記事を取得（関連記事用）
   const allBlogs = await getAllBlogs();
-  const relatedBlogs = allBlogs
-    .filter(
-      (relatedBlog) =>
-        relatedBlog.category.id === blog.category.id &&
-        relatedBlog.id !== blog.id,
-    )
-    .slice(0, 3);
+  const relatedBlogs = allBlogs.filter(
+    (relatedBlog) =>
+      relatedBlog.category.id === blog.category.id &&
+      relatedBlog.id !== blog.id,
+  );
 
   return (
     <div className="min-h-screen bg-gradient-main">
       <LogoLink2 />
-      <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <div className="container mx-auto px-4 py-4 sm:py-8 sm:px-6 lg:px-8">
         {/* パンくずリスト */}
-        <nav className="mb-8 text-sm" aria-label="パンくずリスト">
+        <nav className="mb-4 text-xs sm:mb-8 sm:text-sm" aria-label="パンくずリスト">
           <ol className="flex flex-wrap items-center">
             <li className="flex items-center">
               <Link href="/" className="hover:underline">
@@ -117,13 +115,13 @@ export default async function BlogPostPage({ params }: Props) {
         </nav>
 
         {/* 記事コンテンツ */}
-        <div className="flex flex-col gap-8 lg:flex-row">
+        <div className="flex flex-col gap-6 sm:gap-8 lg:flex-row">
           {/* メインコンテンツ */}
           <article className="lg:w-3/4">
-            <div className="overflow-hidden rounded-lg bg-white/90 shadow-lg backdrop-blur-sm">
+            <div className="overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg">
               {/* アイキャッチ画像 */}
               {blog.eyecatch && (
-                <div className="relative h-64 w-full overflow-hidden md:h-96">
+                <div className="relative h-48 w-full overflow-hidden sm:h-64 md:h-96">
                   <Image
                     src={blog.eyecatch.url}
                     alt={blog.title}
@@ -136,44 +134,44 @@ export default async function BlogPostPage({ params }: Props) {
               )}
 
               {/* 記事ヘッダー */}
-              <div className="p-6 md:p-10">
-                <div className="mb-4 flex flex-wrap items-center gap-4">
+              <div className="p-4 sm:p-6 md:p-10">
+                <div className="mb-3 flex flex-wrap items-center gap-2 sm:mb-4 sm:gap-4">
                   <Link href={`/blogs/${blog.category.slug}`}>
-                    <span className="inline-block rounded border-l-4 border-primary bg-primary-light/10 px-3 py-1 text-sm font-semibold text-primary transition-colors hover:bg-primary/10">
+                    <span className="inline-block rounded-full bg-primary-dark px-2.5 py-0.5 text-xs font-semibold text-white transition-colors hover:bg-primary sm:px-3 sm:py-1 sm:text-sm">
                       {blog.category.name}
                     </span>
                   </Link>
-                  <div className="flex flex-wrap items-center gap-4">
-                    <div className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                      <CalendarIcon className="h-4 w-4 text-primary" />
+                  <div className="flex flex-wrap items-center gap-2 sm:gap-4">
+                    <div className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 sm:px-3 sm:py-1">
+                      <CalendarIcon className="h-3 w-3 text-primary sm:h-4 sm:w-4" />
                       <time
                         dateTime={blog.publishedAt}
-                        className="text-sm font-medium"
+                        className="text-xs font-medium sm:text-sm"
                       >
                         公開:{" "}
                         {new Date(blog.publishedAt).toLocaleDateString(
                           "ja-JP",
                           {
                             year: "numeric",
-                            month: "long",
+                            month: "2-digit",
                             day: "numeric",
                           },
                         )}
                       </time>
                     </div>
                     {blog.updatedAt !== blog.publishedAt && (
-                      <div className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                        <PencilIcon className="h-4 w-4 text-primary" />
+                      <div className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 sm:px-3 sm:py-1">
+                        <PencilIcon className="h-3 w-3 text-primary sm:h-4 sm:w-4" />
                         <time
                           dateTime={blog.updatedAt}
-                          className="text-sm font-medium"
+                          className="text-xs font-medium sm:text-sm"
                         >
                           更新:{" "}
                           {new Date(blog.updatedAt).toLocaleDateString(
                             "ja-JP",
                             {
                               year: "numeric",
-                              month: "long",
+                              month: "2-digit",
                               day: "numeric",
                             },
                           )}
@@ -183,19 +181,19 @@ export default async function BlogPostPage({ params }: Props) {
                   </div>
                 </div>
 
-                <h1 className="mb-6 font-shippori-antique-b1 text-3xl font-bold md:text-4xl">
+                <h1 className="mb-4 font-shippori-antique-b1 text-2xl font-bold sm:mb-6 sm:text-3xl md:text-4xl">
                   {blog.title}
                 </h1>
 
                 {/* タグ */}
                 {tags.length > 0 && (
-                  <div className="mb-6">
-                    <div className="flex flex-wrap gap-2">
+                  <div className="mb-4 sm:mb-6">
+                    <div className="flex flex-wrap gap-1.5 sm:gap-2">
                       {tags.map((tag) => (
                         <Link
                           key={tag.id}
                           href={`/blogs/tags/${tag.slug}`}
-                          className="inline-block rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-800 hover:bg-gray-200"
+                          className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-800 hover:bg-gray-200 sm:px-3 sm:py-1 sm:text-xs"
                           title={tag.description}
                         >
                           #{tag.name}
@@ -207,72 +205,142 @@ export default async function BlogPostPage({ params }: Props) {
 
                 {/* 本文 */}
                 <div
-                  className="prose prose-lg max-w-none prose-headings:font-bold prose-headings:text-black prose-a:text-primary"
+                  className="prose prose-sm max-w-none prose-headings:font-bold prose-headings:text-black prose-a:text-primary-dark prose-a:underline sm:prose-base md:prose-lg"
                   dangerouslySetInnerHTML={{ __html: blog.content }}
                 />
 
                 {/* 記事下部CTAボタン */}
-                <div className="mt-12 flex flex-col items-center justify-center rounded-lg bg-primary/10 p-6 text-center sm:p-10">
-                  <h2 className="mb-4 text-xl font-bold">
-                    川の家おさかで釣り体験をしてみませんか？
-                  </h2>
-                  <p className="mb-6 text-gray-700">
-                    初心者の方も安心！スタッフがサポートします。
-                    家族や友人と楽しい思い出を作りましょう。
-                  </p>
-                  <Link
-                    href="/reservation"
-                    className="inline-block rounded-full bg-primary px-8 py-3 font-bold text-white shadow-md transition-all hover:bg-primary/80"
-                  >
-                    予約する
-                  </Link>
+                <div className="mt-8 overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg sm:mt-12">
+                  <div className="bg-primary-dark p-4">
+                    <h2 className="text-xl font-bold text-white sm:text-2xl">
+                      🎣 川の家おさか 初心者歓迎！釣り体験
+                    </h2>
+                  </div>
+                  <div className="grid gap-4 p-4 md:grid-cols-2 md:gap-6 md:p-6">
+                    <div>
+                      <h3 className="mb-3 text-base font-bold text-primary-dark sm:text-lg">体験の流れ</h3>
+                      <ol className="space-y-2 text-sm text-gray-700 sm:text-base">
+                        <li><span className="font-semibold text-primary-dark">1.</span> 受付→道具レンタル（竿・餌など一式）</li>
+                        <li><span className="font-semibold text-primary-dark">2.</span> 釣り場へ移動（池・川・渓流から選択）</li>
+                        <li><span className="font-semibold text-primary-dark">3.</span> スタッフがサポート！初心者も安心</li>
+                        <li><span className="font-semibold text-primary-dark">4.</span> 釣った魚を天ぷらや塩焼きで堪能</li>
+                      </ol>
+                    </div>
+                    
+                    <div>
+                      <h3 className="mb-3 text-base font-bold text-primary-dark sm:text-lg">料金例（2名）</h3>
+                      <div className="rounded bg-gray-50 p-4 text-sm sm:text-base">
+                        <p>入場料：1,000円（500円×2）</p>
+                        <p>道具レンタル：3,500円～</p>
+                        <p className="mt-2 font-bold">合計：4,500円～</p>
+                        <p className="mt-2 text-xs text-gray-600 sm:text-sm">※魚代・調理代別途</p>
+                        <Link 
+                          href="/fishing" 
+                          className="mt-3 inline-block text-sm font-semibold text-primary-dark underline hover:text-primary sm:text-base"
+                        >
+                          料金詳細はこちら →
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+                  
+                  <div className="border-t bg-primary-light/10 p-5 text-center">
+                    <p className="mb-4 text-sm text-gray-700 sm:text-base">
+                      手ぶらでOK！家族や友人と楽しい思い出を作りませんか？
+                    </p>
+                    <Link
+                      href="/reservation"
+                      className="inline-flex items-center gap-2 rounded-full bg-primary-dark px-8 py-3 text-base font-bold text-white shadow-md transition-all hover:bg-primary sm:text-lg"
+                    >
+                      <span>予約する</span>
+                      <span>→</span>
+                    </Link>
+                  </div>
                 </div>
               </div>
             </div>
 
             {/* 関連記事 */}
             {relatedBlogs.length > 0 && (
-              <div className="mt-12">
-                <h2 className="mb-6 text-2xl font-bold">関連記事</h2>
-                <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                  {relatedBlogs.map((relatedBlog) => (
-                    <div
-                      key={relatedBlog.id}
-                      className="overflow-hidden rounded-lg bg-white shadow-lg transition-all hover:shadow-xl"
-                    >
-                      {relatedBlog.eyecatch && (
-                        <div className="relative h-40 w-full overflow-hidden">
-                          <Image
-                            src={relatedBlog.eyecatch.url}
-                            alt={relatedBlog.title}
-                            fill
-                            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                            className="object-cover transition-all hover:scale-105"
-                          />
-                        </div>
-                      )}
-                      <div className="p-4">
-                        <Link
-                          href={`/blogs/${relatedBlog.category.slug}/${relatedBlog.slug}`}
-                          className="block"
-                        >
-                          <h3 className="mb-2 text-lg font-bold transition-colors hover:text-primary">
-                            {relatedBlog.title}
-                          </h3>
-                        </Link>
-                        <div className="text-xs text-gray-500">
-                          {new Date(relatedBlog.publishedAt).toLocaleDateString(
-                            "ja-JP",
-                            {
-                              year: "numeric",
-                              month: "long",
-                              day: "numeric",
-                            },
-                          )}
-                        </div>
+              <div className="mt-8 sm:mt-12">
+                <div className="overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg">
+                  <div className="bg-primary-dark p-4">
+                    <h2 className="text-xl font-bold text-white sm:text-2xl">
+                      こちらもおすすめ
+                    </h2>
+                  </div>
+                  <div className="p-4 sm:p-6">
+                    <div className="overflow-x-auto">
+                      <div className="flex gap-4 pb-2" style={{ minWidth: 'max-content' }}>
+                        {relatedBlogs.map((relatedBlog) => (
+                          <Link
+                            key={relatedBlog.id}
+                            href={`/blogs/${relatedBlog.category.slug}/${relatedBlog.slug}`}
+                            className="group block flex-shrink-0"
+                            style={{ width: '280px' }}
+                          >
+                            <div className="overflow-hidden rounded-[15px] border-2 border-black bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                              {relatedBlog.eyecatch ? (
+                                <div className="relative h-48 w-full overflow-hidden">
+                                  <Image
+                                    src={relatedBlog.eyecatch.url}
+                                    alt={relatedBlog.title}
+                                    fill
+                                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                                    className="object-cover transition-transform duration-300 group-hover:scale-110"
+                                  />
+                                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                                  <div className="absolute bottom-2 left-2 right-2 translate-y-4 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
+                                    <span className="inline-block rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-primary-dark">
+                                      続きを読む →
+                                    </span>
+                                  </div>
+                                </div>
+                              ) : (
+                                <div className="flex h-48 w-full items-center justify-center bg-gradient-to-br from-primary-light to-primary">
+                                  <span className="text-white">No Image</span>
+                                </div>
+                              )}
+                              <div className="p-4">
+                                <div className="mb-2 flex items-center gap-2">
+                                  <span className="inline-block rounded-full bg-primary-dark/10 px-2 py-0.5 text-xs font-medium text-primary-dark">
+                                    {relatedBlog.category.name}
+                                  </span>
+                                  <div className="flex items-center gap-1 text-xs text-gray-500">
+                                    <CalendarIcon className="h-3 w-3" />
+                                    <time>
+                                      {new Date(relatedBlog.publishedAt).toLocaleDateString(
+                                        "ja-JP",
+                                        {
+                                          year: "numeric",
+                                          month: "2-digit",
+                                          day: "numeric",
+                                        },
+                                      )}
+                                    </time>
+                                  </div>
+                                </div>
+                                <h3 className="line-clamp-2 text-base font-bold text-gray-800 transition-colors duration-300 group-hover:text-primary-dark sm:text-lg">
+                                  {relatedBlog.title}
+                                </h3>
+                                {relatedBlog.description && (
+                                  <p className="mt-2 line-clamp-2 text-xs text-gray-600 sm:text-sm">
+                                    {relatedBlog.description}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          </Link>
+                        ))}
                       </div>
                     </div>
-                  ))}
+                  </div>
+                  {/* スクロールヒント */}
+                  {relatedBlogs.length > 1 && (
+                    <div className="pb-4 text-center">
+                      <p className="text-xs text-gray-500">← 横にスクロールできます →</p>
+                    </div>
+                  )}
                 </div>
               </div>
             )}
@@ -280,67 +348,80 @@ export default async function BlogPostPage({ params }: Props) {
 
           {/* サイドバー */}
           <aside className="lg:w-1/4">
-            <div className="sticky top-24 space-y-8">
+            <div className="sticky top-24 space-y-6">
               {/* カテゴリナビゲーション */}
-              <div className="rounded-lg bg-white/90 p-6 shadow-lg backdrop-blur-sm">
-                <h2 className="mb-4 text-xl font-bold">カテゴリ</h2>
-                <ul className="space-y-2">
-                  {categories.map((category) => (
-                    <li key={category.id}>
-                      <Link
-                        href={`/blogs/${category.slug}`}
-                        className={`block rounded px-3 py-2 transition-colors ${
-                          category.id === blog.category.id
-                            ? "rounded border-l-4 border-primary bg-primary/5 px-3 py-2 font-semibold text-primary hover:bg-primary/10"
-                            : "rounded px-3 py-2 hover:bg-gray-200"
-                        }`}
-                      >
-                        {category.name}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
+              <div className="overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg">
+                <div className="bg-primary-dark p-4">
+                  <h2 className="text-xl font-bold text-white">カテゴリ</h2>
+                </div>
+                <div className="p-6">
+                  <ul className="space-y-2">
+                    {categories.map((category) => (
+                      <li key={category.id}>
+                        <Link
+                          href={`/blogs/${category.slug}`}
+                          className={`block rounded-full px-4 py-2 text-sm font-medium transition-all ${
+                            category.id === blog.category.id
+                              ? "bg-primary-dark text-white hover:bg-primary"
+                              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                          }`}
+                        >
+                          {category.name}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
 
               {/* タグクラウド */}
               {tags.length > 0 && (
-                <div className="rounded-lg bg-white/90 p-6 shadow-lg backdrop-blur-sm">
-                  <h2 className="mb-4 text-xl font-bold">タグ</h2>
-                  <div className="flex flex-wrap gap-2">
-                    {tags.map((tag) => (
-                      <Link
-                        key={tag.id}
-                        href={`/blogs/tags/${tag.slug}`}
-                        className="inline-block rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-800 hover:bg-gray-200"
-                        title={tag.description}
-                      >
-                        #{tag.name}
-                      </Link>
-                    ))}
+                <div className="overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg">
+                  <div className="bg-primary-dark p-4">
+                    <h2 className="text-xl font-bold text-white">タグ</h2>
                   </div>
-                  <div className="mt-4 text-right">
-                    <Link
-                      href="/blogs/tags"
-                      className="text-sm font-medium text-primary-dark hover:underline"
-                    >
-                      すべてのタグを見る →
-                    </Link>
+                  <div className="p-6">
+                    <div className="flex flex-wrap gap-2">
+                      {tags.map((tag) => (
+                        <Link
+                          key={tag.id}
+                          href={`/blogs/tags/${tag.slug}`}
+                          className="inline-block rounded-full bg-primary-dark/10 px-3 py-1 text-xs font-medium text-primary-dark transition-colors hover:bg-primary-dark hover:text-white"
+                          title={tag.description}
+                        >
+                          #{tag.name}
+                        </Link>
+                      ))}
+                    </div>
+                    <div className="mt-4 text-right">
+                      <Link
+                        href="/blogs/tags"
+                        className="text-sm font-semibold text-primary-dark transition-colors hover:text-primary"
+                      >
+                        すべてのタグを見る →
+                      </Link>
+                    </div>
                   </div>
                 </div>
               )}
 
               {/* 予約CTAボタン */}
-              <div className="rounded-lg bg-white/90 p-6 shadow-lg backdrop-blur-sm">
-                <h2 className="mb-4 text-lg font-bold">川の家へのご予約</h2>
-                <p className="mb-4 text-sm text-gray-700">
-                  釣り体験のご予約はオンラインで簡単にできます。
-                </p>
-                <Link
-                  href="/reservation"
-                  className="block rounded-full bg-primary px-4 py-2 text-center font-bold text-white transition-all hover:bg-primary/80"
-                >
-                  今すぐ予約する
-                </Link>
+              <div className="overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg">
+                <div className="bg-primary-dark p-4">
+                  <h2 className="text-xl font-bold text-white">川の家おさか</h2>
+                </div>
+                <div className="p-6">
+                  <p className="mb-6 text-sm text-gray-700">
+                    釣り体験のご予約はオンラインで簡単にできます。
+                  </p>
+                  <Link
+                    href="/reservation"
+                    className="flex items-center justify-center gap-2 rounded-full bg-primary-dark px-6 py-3 font-bold text-white transition-all hover:bg-primary"
+                  >
+                    <span>今すぐ予約する</span>
+                    <span className="text-xl">→</span>
+                  </Link>
+                </div>
               </div>
             </div>
           </aside>

--- a/src/app/blogs/[category]/page.tsx
+++ b/src/app/blogs/[category]/page.tsx
@@ -1,15 +1,11 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import {
   getAllBlogCategories,
   getBlogsByCategory,
   type BlogCategory,
 } from "@/libs/client";
-import { BlogHeader } from "@/app/_components/blog/BlogHeader";
-import { CategoryNavigation } from "@/app/_components/blog/CategoryNavigation";
-import { BlogCard } from "@/app/_components/blog/BlogCard";
-import { LogoLink2 } from "@/app/_components/common/LogoLink2";
+import { CategoryPageClient } from "./CategoryPageClient";
 
 type Props = {
   params: {
@@ -59,45 +55,10 @@ export default async function CategoryPage({ params }: Props) {
   const blogs = await getBlogsByCategory(currentCategory.id);
 
   return (
-    <div className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
-      <LogoLink2 />
-      <div className="container mx-auto">
-        <BlogHeader
-          title={currentCategory.name}
-          description={`川の家おさかブログの「${currentCategory.name}」カテゴリの記事一覧です。`}
-          backLink={{
-            href: "/blogs",
-            text: "ブログトップに戻る",
-          }}
-        />
-
-        <CategoryNavigation
-          categories={categories}
-          activeCategory={currentCategory.slug}
-          className="mb-12"
-        />
-
-        {/* 記事一覧 */}
-        {blogs.length > 0 ? (
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-            {blogs.map((blog) => (
-              <BlogCard key={blog.id} blog={blog} />
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg bg-white/80 p-8 text-center shadow-lg backdrop-blur-sm">
-            <p className="text-lg font-medium">
-              このカテゴリにはまだ記事がありません。
-            </p>
-            <Link
-              href="/blogs"
-              className="mt-4 inline-block rounded-full bg-primary px-6 py-2 text-white transition-all hover:bg-primary/80"
-            >
-              ブログトップに戻る
-            </Link>
-          </div>
-        )}
-      </div>
-    </div>
+    <CategoryPageClient
+      currentCategory={currentCategory}
+      categories={categories}
+      blogs={blogs}
+    />
   );
 }

--- a/src/app/blogs/all/AllBlogsPageClient.tsx
+++ b/src/app/blogs/all/AllBlogsPageClient.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import Image from "next/image";
+import { useState } from "react";
+import { Blog, BlogCategory } from "@/libs/client";
+import { LogoLink2 } from "@/app/_components/common/LogoLink2";
+import { CategoryNavigation } from "@/app/_components/blog/CategoryNavigation";
+import { CalendarIcon } from "lucide-react";
+
+type AllBlogsPageClientProps = {
+  blogs: Blog[];
+  categories: BlogCategory[];
+};
+
+export function AllBlogsPageClient({ blogs, categories }: AllBlogsPageClientProps) {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  
+  // カテゴリーでフィルタリング
+  const filteredBlogs = selectedCategory
+    ? blogs.filter(blog => blog.category.slug === selectedCategory)
+    : blogs;
+
+  // 日付フォーマット関数
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+  };
+
+  return (
+    <section className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
+      <LogoLink2 />
+      <div className="container mx-auto">
+        {/* ヘッダー */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-8 md:mb-12"
+        >
+          <Link
+            href="/blogs"
+            className="mb-4 inline-flex items-center gap-2 text-sm font-medium transition-colors hover:text-primary"
+          >
+            <span>←</span>
+            <span>ブログトップに戻る</span>
+          </Link>
+          <p className="text-base font-semibold md:text-2xl">ALL POSTS</p>
+          <h1 className="mb-4 font-shippori-antique-b1 text-3xl font-medium md:text-5xl">
+            すべての記事
+          </h1>
+          <p className="max-w-2xl text-gray-700">
+            川の家おさかのブログ記事をすべて一覧で表示しています。
+            {blogs.length}件の記事があります。
+          </p>
+        </motion.div>
+
+        {/* カテゴリーフィルター */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+        >
+          <CategoryNavigation
+            categories={categories}
+            activeCategory={selectedCategory}
+            className="mb-12"
+            showAllCount={blogs.length}
+            categoryCounts={categories.reduce((acc, cat) => {
+              acc[cat.slug] = blogs.filter(b => b.category.slug === cat.slug).length;
+              return acc;
+            }, {} as Record<string, number>)}
+            variant="filter"
+            onCategoryClick={setSelectedCategory}
+          />
+        </motion.div>
+
+        {/* 記事一覧 */}
+        {filteredBlogs.length > 0 ? (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
+            className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+          >
+            {filteredBlogs.map((blog, index) => (
+              <BlogCard 
+                key={blog.id} 
+                blog={blog} 
+                index={index}
+                formatDate={formatDate}
+              />
+            ))}
+          </motion.div>
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="rounded-[20px] border-2 border-black bg-white p-8 text-center shadow-lg"
+          >
+            <p className="mb-4 text-lg font-medium">
+              該当する記事はありません。
+            </p>
+            <button
+              onClick={() => setSelectedCategory(null)}
+              className="rounded-full border-2 border-black bg-gradient-main px-6 py-2 font-medium transition-all hover:bg-primary hover:text-white"
+            >
+              すべての記事を表示
+            </button>
+          </motion.div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ブログカード
+const BlogCard = ({ 
+  blog, 
+  index,
+  formatDate 
+}: { 
+  blog: Blog; 
+  index: number;
+  formatDate: (date: string) => string;
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: index * 0.05 }}
+      whileHover={{ y: -5 }}
+      className="h-full"
+    >
+      <Link href={`/blogs/${blog.category.slug}/${blog.slug}`}>
+        <div className="group flex h-full flex-col overflow-hidden rounded-[20px] border-2 border-black bg-white shadow-lg transition-all hover:shadow-xl">
+          <div className="relative h-48">
+            {blog.eyecatch ? (
+              <Image
+                src={blog.eyecatch.url}
+                alt={blog.title}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gray-200">
+                <span className="text-gray-400">No Image</span>
+              </div>
+            )}
+            <div className="absolute left-3 top-3 rounded-full bg-primary-dark px-3 py-1 text-xs font-bold text-white">
+              {blog.category.name}
+            </div>
+          </div>
+
+          <div className="flex flex-1 flex-col p-5">
+            <div className="mb-2 flex items-center text-xs text-gray-500">
+              <CalendarIcon className="mr-1 h-3 w-3" />
+              <p>{formatDate(blog.publishedAt)}</p>
+            </div>
+            <h3 className="mb-2 line-clamp-2 text-lg font-bold text-gray-800 transition-colors group-hover:text-primary">
+              {blog.title}
+            </h3>
+            {blog.description && (
+              <p className="mb-3 line-clamp-2 text-sm text-gray-600">
+                {blog.description}
+              </p>
+            )}
+
+            <div className="mt-auto">
+              {blog.tags && blog.tags.length > 0 && (
+                <div className="mb-3 flex flex-wrap gap-1">
+                  {blog.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                    >
+                      #{tag.name}
+                    </span>
+                  ))}
+                  {blog.tags.length > 3 && (
+                    <span className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+                      +{blog.tags.length - 3}
+                    </span>
+                  )}
+                </div>
+              )}
+              <div className="flex items-center justify-end">
+                <motion.span
+                  whileHover={{ x: 3 }}
+                  className="text-sm font-semibold text-primary-dark"
+                >
+                  続きを読む →
+                </motion.span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </motion.div>
+  );
+};

--- a/src/app/blogs/all/AllBlogsPageClient.tsx
+++ b/src/app/blogs/all/AllBlogsPageClient.tsx
@@ -15,7 +15,7 @@ type AllBlogsPageClientProps = {
 };
 
 export function AllBlogsPageClient({ blogs, categories }: AllBlogsPageClientProps) {
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
   
   // カテゴリーでフィルタリング
   const filteredBlogs = selectedCategory
@@ -72,7 +72,7 @@ export function AllBlogsPageClient({ blogs, categories }: AllBlogsPageClientProp
               return acc;
             }, {} as Record<string, number>)}
             variant="filter"
-            onCategoryClick={setSelectedCategory}
+            onCategoryClick={(slug) => setSelectedCategory(slug ?? undefined)}
           />
         </motion.div>
 
@@ -104,7 +104,7 @@ export function AllBlogsPageClient({ blogs, categories }: AllBlogsPageClientProp
               該当する記事はありません。
             </p>
             <button
-              onClick={() => setSelectedCategory(null)}
+              onClick={() => setSelectedCategory(undefined)}
               className="rounded-full border-2 border-black bg-gradient-main px-6 py-2 font-medium transition-all hover:bg-primary hover:text-white"
             >
               すべての記事を表示

--- a/src/app/blogs/all/page.tsx
+++ b/src/app/blogs/all/page.tsx
@@ -1,10 +1,6 @@
 import { Metadata } from "next";
-import Link from "next/link";
 import { getAllBlogs, getAllBlogCategories } from "@/libs/client";
-import { BlogHeader } from "@/app/_components/blog/BlogHeader";
-import { CategoryNavigation } from "@/app/_components/blog/CategoryNavigation";
-import { BlogCard } from "@/app/_components/blog/BlogCard";
-import { LogoLink2 } from "@/app/_components/common/LogoLink2";
+import { AllBlogsPageClient } from "./AllBlogsPageClient";
 
 export const metadata: Metadata = {
   title: "全ての記事 | 川の家おさかブログ",
@@ -21,46 +17,5 @@ export default async function AllBlogsPage() {
     getAllBlogCategories(),
   ]);
 
-  return (
-    <div className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
-      <LogoLink2 />
-      <div className="container mx-auto">
-        <BlogHeader
-          title="全ての記事"
-          description="川の家おさかのブログ記事をすべて一覧で表示しています。"
-          backLink={{
-            href: "/blogs",
-            text: "ブログトップに戻る",
-          }}
-        />
-
-        <CategoryNavigation
-          categories={categories}
-          className="mb-12"
-          activeCategory="all"
-        />
-
-        {/* 記事一覧 */}
-        {blogs.length > 0 ? (
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-            {blogs.map((blog) => (
-              <BlogCard key={blog.id} blog={blog} />
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg bg-white/80 p-8 text-center shadow-lg backdrop-blur-sm">
-            <p className="text-lg font-medium">
-              現在、ブログ記事はありません。
-            </p>
-            <Link
-              href="/blogs"
-              className="mt-4 inline-block rounded-full bg-primary px-6 py-2 text-white transition-all hover:bg-primary/80"
-            >
-              ブログトップに戻る
-            </Link>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  return <AllBlogsPageClient blogs={blogs} categories={categories} />;
 }

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -1,10 +1,6 @@
 import { Metadata } from "next";
 import { getAllBlogCategories, getAllBlogs } from "@/libs/client";
-import Link from "next/link";
-import { BlogHeader } from "../_components/blog/BlogHeader";
-import { CategoryNavigation } from "../_components/blog/CategoryNavigation";
-import { BlogCard } from "../_components/blog/BlogCard";
-import { LogoLink2 } from "../_components/common/LogoLink2";
+import { BlogPageClient } from "./BlogPageClient";
 
 export const metadata: Metadata = {
   title: "ブログ | 川の家おさか - 下呂市小坂町の釣り場",
@@ -25,34 +21,10 @@ export default async function BlogPage() {
   const latestSixBlogs = latestBlogs.slice(0, 6);
 
   return (
-    <div className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
-      <LogoLink2 />
-      <div className="container mx-auto">
-        <BlogHeader
-          title="ブログ"
-          description="下呂市小坂町の釣り場「川の家おさか」の釣り情報、初心者向けガイド、釣った魚のレシピなど様々な情報を発信しています。"
-        />
-
-        <CategoryNavigation categories={categories} className="mb-12" />
-
-        {/* 最新記事一覧 */}
-        <h2 className="mb-6 text-2xl font-bold">最新記事</h2>
-        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-          {latestSixBlogs.map((blog) => (
-            <BlogCard key={blog.id} blog={blog} />
-          ))}
-        </div>
-
-        {/* すべての記事を見るボタン */}
-        <div className="mt-12 text-center">
-          <Link
-            href="/blogs/all"
-            className="rounded-full bg-primary px-6 py-3 text-white shadow-lg transition-all duration-300 hover:bg-primary-dark"
-          >
-            すべての記事を見る
-          </Link>
-        </div>
-      </div>
-    </div>
+    <BlogPageClient 
+      categories={categories} 
+      latestBlogs={latestSixBlogs}
+      allBlogs={latestBlogs}
+    />
   );
 }

--- a/src/app/blogs/tags/TagsPageClient.tsx
+++ b/src/app/blogs/tags/TagsPageClient.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { LogoLink2 } from "@/app/_components/common/LogoLink2";
+import { TagIcon } from "lucide-react";
+
+type TagWithCount = {
+  tag: {
+    id: string;
+    name: string;
+    slug: string;
+  };
+  count: number;
+};
+
+type TagsPageClientProps = {
+  initialTags: TagWithCount[];
+};
+
+export function TagsPageClient({ initialTags }: TagsPageClientProps) {
+  const tagsWithCount = initialTags;
+
+  return (
+    <section className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
+      <LogoLink2 />
+      <div className="container mx-auto">
+        {/* ヘッダー */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="mb-8 md:mb-12"
+        >
+          <p className="text-base font-semibold md:text-2xl">TAGS</p>
+          <h1 className="mb-4 font-shippori-antique-b1 text-3xl font-medium md:text-5xl">
+            タグ一覧
+          </h1>
+          <p className="max-w-2xl text-gray-700">
+            川の家おさかブログのすべてのタグ一覧です。興味のあるタグをクリックして関連記事を探してください。
+          </p>
+        </motion.div>
+
+        {/* タグ一覧 */}
+        {tagsWithCount.length > 0 ? (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
+          >
+            {/* 人気のタグ */}
+            {tagsWithCount.length > 5 && (
+              <div className="mb-12">
+                <motion.h2
+                  initial={{ opacity: 0, x: -20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.5 }}
+                  className="mb-6 flex items-center gap-2 font-shippori-antique-b1 text-2xl font-bold md:text-3xl"
+                >
+                  <span className="rounded-full bg-primary p-2 text-white">
+                    <TagIcon className="h-5 w-5" />
+                  </span>
+                  人気のタグ
+                </motion.h2>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {tagsWithCount.slice(0, 6).map((item, index) => (
+                    <TagCard
+                      key={item.tag.id}
+                      item={item}
+                      index={index}
+                      isPopular={true}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* すべてのタグ */}
+            <motion.h2
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.5, delay: 0.3 }}
+              className="mb-6 font-shippori-antique-b1 text-2xl font-bold md:text-3xl"
+            >
+              すべてのタグ
+            </motion.h2>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+              {tagsWithCount.map((item, index) => (
+                <TagCard key={item.tag.id} item={item} index={index} />
+              ))}
+            </div>
+          </motion.div>
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="rounded-[20px] border-2 border-black bg-white p-8 text-center shadow-lg"
+          >
+            <p className="mb-4 text-lg font-medium">
+              現在、ブログにタグはありません。
+            </p>
+            <Link
+              href="/blogs"
+              className="group inline-flex items-center gap-2 font-bold text-black transition-colors hover:text-primary"
+            >
+              <span>ブログトップに戻る</span>
+              <span className="grid place-items-center rounded-full border-2 border-black bg-white p-2 transition-transform group-hover:translate-x-1">
+                <Image
+                  src="/common/arrow.svg"
+                  alt="矢印"
+                  width={16}
+                  height={16}
+                />
+              </span>
+            </Link>
+          </motion.div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// タグカードコンポーネント
+const TagCard = ({
+  item,
+  index,
+  isPopular = false,
+}: {
+  item: TagWithCount;
+  index: number;
+  isPopular?: boolean;
+}) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: index * 0.05 }}
+    >
+      <Link href={`/blogs/tags/${item.tag.slug}`}>
+        <motion.div
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          className={`group relative overflow-hidden rounded-[20px] border-2 border-black bg-white p-4 shadow-lg transition-all hover:shadow-xl ${
+            isPopular ? "md:p-6" : ""
+          }`}
+        >
+          {/* 背景のアクセント */}
+          <div className="absolute -right-4 -top-4 h-16 w-16 rounded-full bg-primary/10 transition-transform group-hover:scale-150" />
+          
+          {/* コンテンツ */}
+          <div className="relative z-10">
+            <div className="mb-2 flex items-start justify-between">
+              <h3 className={`font-bold text-gray-800 transition-colors group-hover:text-primary ${
+                isPopular ? "text-lg md:text-xl" : "text-base"
+              }`}>
+                {item.tag.name}
+              </h3>
+              {isPopular && (
+                <span className="rounded-full bg-yellow-400 px-2 py-1 text-xs font-bold text-yellow-900">
+                  人気
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-gray-600">
+              {item.count}件の記事
+            </p>
+          </div>
+
+          {/* ホバー時の矢印 */}
+          <motion.div
+            initial={{ opacity: 0, x: -10 }}
+            whileHover={{ opacity: 1, x: 0 }}
+            className="absolute bottom-4 right-4 text-primary opacity-0 transition-opacity group-hover:opacity-100"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+              />
+            </svg>
+          </motion.div>
+        </motion.div>
+      </Link>
+    </motion.div>
+  );
+};

--- a/src/app/blogs/tags/page.tsx
+++ b/src/app/blogs/tags/page.tsx
@@ -1,9 +1,6 @@
 import { Metadata } from "next";
-import Link from "next/link";
 import { getAllTagsWithCount } from "@/libs/client";
-import { LogoLink2 } from "@/app/_components/common/LogoLink2";
-import { BlogHeader } from "@/app/_components/blog/BlogHeader";
-import { TagLink } from "@/app/_components/blog/TagLink";
+import { TagsPageClient } from "./TagsPageClient";
 
 export const metadata: Metadata = {
   title: "タグ一覧 | 川の家おさかブログ",
@@ -17,59 +14,5 @@ export const metadata: Metadata = {
 export default async function TagsPage() {
   const tagsWithCount = await getAllTagsWithCount();
 
-  return (
-    <div className="min-h-screen bg-gradient-main px-4 py-8 sm:px-6 lg:px-8">
-      <LogoLink2 />
-      <div className="container mx-auto">
-        <BlogHeader
-          title="タグ一覧"
-          description="川の家おさかブログのすべてのタグ一覧です。興味のあるタグをクリックして関連記事を探してください。"
-          backLink={{
-            href: "/blogs",
-            text: "ブログトップに戻る",
-          }}
-        />
-
-        {/* タグ一覧 */}
-        {tagsWithCount.length > 0 ? (
-          <div className="mx-auto max-w-4xl rounded-lg bg-white/80 p-8 shadow-lg backdrop-blur-sm">
-            <div className="flex flex-wrap gap-4">
-              {tagsWithCount.map((item) => (
-                <TagLink key={item.tag.id} tag={item.tag} count={item.count} />
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="rounded-lg bg-white/80 p-8 text-center shadow-lg backdrop-blur-sm">
-            <p className="text-lg font-medium">
-              現在、ブログにタグはありません。
-            </p>
-            <Link
-              href="/blogs"
-              className="mt-4 inline-block rounded-full bg-primary px-6 py-2 text-white transition-all hover:bg-primary/80"
-            >
-              ブログトップに戻る
-            </Link>
-          </div>
-        )}
-
-        {/* 人気のタグ (もしあれば) */}
-        {tagsWithCount.length > 5 && (
-          <div className="mt-12">
-            <h2 className="mb-6 text-2xl font-bold">人気のタグ</h2>
-            <div className="flex flex-wrap gap-4">
-              {tagsWithCount.slice(0, 5).map((item) => (
-                <TagLink
-                  key={item.tag.id}
-                  tag={item.tag}
-                  count={item.count}
-                  isPopular={true}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  return <TagsPageClient initialTags={tagsWithCount} />;
 }


### PR DESCRIPTION
## Summary
- ブログページ全体のUIをトップページと同じデザインシステムに統一
- タグページを新しいカード形式で実装
- カテゴリーナビゲーションの共通コンポーネント化

## 主な変更点

### タグページ (`/blogs/tags`)
- サーバーコンポーネントとクライアントコンポーネントの分離
- カード形式のタグ表示（ホバーエフェクト付き）
- 人気タグセクションの実装（6件以上ある場合）
- Framer Motionによるアニメーション効果

### ブログページ (`/blogs`, `/blogs/all`, `/blogs/[category]`)
- トップページと同じフォントスタイル（Shippori Antique B1）を使用
- 最新記事を大きく表示、その他の記事は横スクロール形式
- カードデザインを`rounded-[20px]`と黒いボーダーで統一
- 各カテゴリーの記事数表示

### コンポーネントの最適化
- `CategoryNavigation`コンポーネントを拡張して重複を削減
- 2つのバリエーション対応：通常のナビゲーション（リンク）とフィルター機能（ボタン）
- 選択中のカテゴリーの背景色を`bg-primary-dark`に変更して視認性を向上

## Test plan
- [ ] `/blogs`ページが正しく表示される
- [ ] `/blogs/tags`ページでタグがカード形式で表示される
- [ ] `/blogs/all`ページでカテゴリーフィルターが動作する
- [ ] `/blogs/[category]`ページで各カテゴリーが正しく表示される
- [ ] すべてのページでアニメーションが滑らかに動作する
- [ ] カテゴリーナビゲーションのホバー効果が正しく動作する

🤖 Generated with [Claude Code](https://claude.ai/code)